### PR TITLE
Chore/bump lodash version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "http-status-codes": "1.0.4",
     "humanize-string": "1.0.1",
-    "lodash": "2.4.1",
+    "lodash": "4.17.10",
     "node-custom-errors": "0.1.5",
     "string": "3.0.0"
   },
@@ -45,6 +45,6 @@
     "supertest": "0.15.0"
   },
   "peerDependencies": {
-    "lodash": "2.4.1"
+    "lodash": "4.17.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     "request": "2.53.0",
     "should": "4.6.1",
     "supertest": "0.15.0"
+  },
+  "peerDependencies": {
+    "lodash": "2.4.1"
   }
 }


### PR DESCRIPTION
> Versions of lodash before 4.17.5 are vulnerable to prototype pollution

https://nodesecurity.io/advisories/577

Depends on #7 